### PR TITLE
Making some UI adjusts post Zach's UI push to keep consistency

### DIFF
--- a/COMP-49X-24-25-PhoneArt/Views/CanvasView.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/CanvasView.swift
@@ -143,7 +143,7 @@ struct CanvasView: View {
                 makeZoomSlider()
             }
             .padding(.top, 50)
-            .padding(.trailing, -20)
+            .padding(.trailing, -30)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
       
             VStack {
@@ -330,12 +330,17 @@ struct CanvasView: View {
                         }
                     
                     // Import View
-                    ImportArtworkView(onImportSuccess: { artworkString in // Pass the callback
-                        // Decode and apply the imported artwork string
-                        self.applyImportedArtwork(artworkString)
-                        // Dismiss the import sheet
-                        self.showImportSheet = false
-                    })
+                    ImportArtworkView(
+                        onImportSuccess: { artworkString in // Pass the callback
+                            // Decode and apply the imported artwork string
+                            self.applyImportedArtwork(artworkString)
+                            // Dismiss the import sheet
+                            self.showImportSheet = false
+                        },
+                        onClose: { // Add the onClose callback
+                            self.showImportSheet = false
+                        }
+                    )
                     .onChange(of: showImportSheet) { _, newValue in
                         // If the parent state changes to false, ensure dismissal logic runs if needed
                         if !newValue {
@@ -726,14 +731,19 @@ struct CanvasView: View {
      /// Creates the reset position button
     private func makeResetButton() -> some View {
         Button(action: resetPosition) {
-            Rectangle()
-                .foregroundColor(Color(uiColor: .systemBlue))
+            Rectangle() // Keep the Rectangle as the base shape
+                .foregroundColor(.clear) // Make the rectangle transparent
                 .frame(width: 40, height: 40)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
-                .overlay(
+                .background(Color(uiColor: .systemBackground)) // Apply background color
+                .cornerRadius(8) // Apply corner radius
+                .overlay( // Apply icon overlay
                     Image(systemName: "arrow.down.forward.and.arrow.up.backward")
                         .font(.system(size: 20))
-                        .foregroundColor(Color(uiColor: .systemBackground))
+                        .foregroundColor(Color(uiColor: .systemBlue)) // Use systemBlue for icon
+                )
+                .overlay( // Apply border overlay
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
                 )
         }
         .accessibilityIdentifier("Reset Position")
@@ -900,17 +910,25 @@ struct CanvasView: View {
     }
      /// Creates the share button for the top navigation bar
     private func makeShareButton() -> some View {
-        VStack(spacing: 15) {
+        VStack(spacing: 20) { // Increased spacing from 10 to 20
             // Import button
             Button(action: {
                 showImportSheet = true
             }) {
                 VStack {
                     Image(systemName: "plus")
-                        .font(.system(size: 24))
-                    Text("Import")
-                        .font(.caption)
+                        .font(.system(size: 20)) // Slightly smaller icon to fit
+                        .foregroundColor(Color(uiColor: .systemBlue))
+                    // Text("Import") removed
                 }
+                .padding(8)
+                .frame(width: 40, height: 40) // Changed size to match reset button
+                .background(Color(uiColor: .systemBackground))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
+                )
             }
             .accessibilityIdentifier("Import Button")
             
@@ -930,10 +948,18 @@ struct CanvasView: View {
             } label: {
                 VStack {
                     Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 24))
-                    Text("Share")
-                        .font(.caption)
+                        .font(.system(size: 20)) // Slightly smaller icon to fit
+                        .foregroundColor(Color(uiColor: .systemBlue))
+                    // Text("Share") removed
                 }
+                .padding(8)
+                .frame(width: 40, height: 40) // Changed size to match reset button
+                .background(Color(uiColor: .systemBackground))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
+                )
             }
             .accessibilityIdentifier("Share Button")
         }

--- a/COMP-49X-24-25-PhoneArt/Views/ImportArtworkView.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/ImportArtworkView.swift
@@ -17,6 +17,8 @@ struct ImportArtworkView: View {
     
     // Callback to pass successful import data back
     var onImportSuccess: ((String) -> Void)?
+    // Add callback for closing the sheet
+    var onClose: (() -> Void)?
     
     // State for showing alerts
     @State private var showingAlert = false
@@ -109,9 +111,9 @@ struct ImportArtworkView: View {
             .fixedSize(horizontal: true, vertical: false)
             .accessibilityIdentifier("Import Button")
 
-            // Close button (using dismiss)
+            // Close button (using new onClose callback)
             Button("Close") {
-                dismiss()
+                onClose?() // Call the new callback
             }
             .foregroundColor(.blue)
             .padding(.top, 5)
@@ -234,5 +236,6 @@ extension ImportArtworkView.ImportResult {
 }
 
 #Preview {
-    ImportArtworkView()
+    // Update preview to provide a dummy onClose action
+    ImportArtworkView(onClose: { print("Preview Close Tapped") })
 } 


### PR DESCRIPTION
# Overview

**Type of Change:** Refactoring / UI Improvement

**Summary:** This pull request refactors the styling of several control buttons (Import, Share, Center) on the main canvas view to ensure visual consistency with the primary menu buttons located at the bottom of the screen. This improves the overall look and feel and adheres to a unified design language.

## UI/UX Implementation

Updated the visual styling (e.g., size, padding, background, foreground color, corner radius, font weight) of the following buttons in the main canvas interface (`CanvasView.swift` or relevant view file):
*   The button that likely triggers the import artwork flow.
*   The button used for sharing or exporting artwork.
*   The button used for centering the canvas view (or similar view manipulation).

These buttons now share the same visual style as the main tool/menu buttons typically found in a bottom bar or panel, creating a more cohesive user interface.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

No changes made.

## End-to-End Testing Instructions

1.  Launch the application and navigate to the main canvas view.
2.  Observe the buttons used for importing, sharing, and centering the view.
3.  **Verify:** Confirm that these buttons now visually match the style of the main menu buttons (typically located at the bottom, e.g., for selecting tools, shapes, or colors). Check aspects like size, color, borders, and text style for consistency.