### PR TITLE
Implemented Gallery View UI

### DIFF
--- a/COMP-49X-24-25-PhoneArt/Views/ColorPropertiesPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/ColorPropertiesPanel.swift
@@ -46,6 +46,9 @@ struct ColorPropertiesPanel: View {
    /// Callback function to switch to the Shapes panel
    /// Executed when the user taps the Shapes button
    var onSwitchToShapes: () -> Void
+
+   /// Callback function to switch to the Gallery panel
+  var onSwitchToGallery: () -> Void
   
    // MARK: - Initialization
   
@@ -55,12 +58,16 @@ struct ColorPropertiesPanel: View {
    ///   - selectedColor: Binding to the currently selected color that will be applied to shapes
    ///   - onSwitchToProperties: Callback function executed when switching to the Properties panel
    ///   - onSwitchToShapes: Callback function executed when switching to the Shapes panel
-   init(isShowing: Binding<Bool>, selectedColor: Binding<Color>, onSwitchToProperties: @escaping () -> Void, onSwitchToShapes: @escaping () -> Void) {
-       self._isShowing = isShowing
-       self._selectedColor = selectedColor
-       self.onSwitchToProperties = onSwitchToProperties
-       self.onSwitchToShapes = onSwitchToShapes
-   }
+   ///   - onSwitchToGallery: Callback function executed when switching to the Gallery panel
+    init(isShowing: Binding<Bool>, selectedColor: Binding<Color>, onSwitchToProperties: @escaping () -> Void, onSwitchToShapes: @escaping () -> Void, onSwitchToGallery: @escaping () -> Void) {
+      self._isShowing = isShowing
+      self._selectedColor = selectedColor
+      self.onSwitchToProperties = onSwitchToProperties
+      self.onSwitchToShapes = onSwitchToShapes
+      self.onSwitchToGallery = onSwitchToGallery
+    }
+
+
  
    // MARK: - Body
   
@@ -159,6 +166,11 @@ struct ColorPropertiesPanel: View {
            Spacer() // Spacer between buttons for equal distribution
            
            makeShapesButton()
+
+           Spacer() // Spacer between buttons for equal distribution
+         
+           // Add the Gallery Button
+           makeGalleryButton()
            
            Spacer() // Spacer between buttons for equal distribution
            
@@ -170,11 +182,11 @@ struct ColorPropertiesPanel: View {
            }) {
                Rectangle()
                    .foregroundColor(Color(uiColor: .systemBackground))
-                   .frame(width: 60, height: 60)
+                   .frame(width: 50, height: 50)
                    .cornerRadius(8)
                    .overlay(
                        Image(systemName: "xmark")
-                           .font(.system(size: 24))
+                           .font(.system(size: 22))
                            .foregroundColor(Color(uiColor: .systemBlue))
                    )
                    .overlay(
@@ -213,11 +225,11 @@ struct ColorPropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "slider.horizontal.3")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .overlay(
@@ -235,11 +247,11 @@ struct ColorPropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "square.3.stack.3d")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .shadow(radius: 2)
@@ -254,11 +266,11 @@ struct ColorPropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "square.on.square")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .overlay(
@@ -267,6 +279,28 @@ struct ColorPropertiesPanel: View {
                )
        }
        .accessibilityIdentifier("Shapes Button")
+   }
+
+   /// Creates a button for the Gallery (placeholder).
+   internal func makeGalleryButton() -> some View {
+       Button(action: {
+           onSwitchToGallery() // Call the gallery switch callback
+       }) {
+           Rectangle()
+               .foregroundColor(Color(uiColor: .systemBackground))
+               .frame(width: 50, height: 50) // Set size
+               .cornerRadius(8)
+               .overlay(
+                   Image(systemName: "photo.on.rectangle.angled")
+                       .font(.system(size: 22)) // Set size
+                       .foregroundColor(Color(uiColor: .systemBlue))
+               )
+               .overlay(
+                   RoundedRectangle(cornerRadius: 8)
+                       .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
+               )
+       }
+       .accessibilityIdentifier("Gallery Button")
    }
 }
 
@@ -508,7 +542,8 @@ struct ColorPropertiesPanel_Previews: PreviewProvider {
            isShowing: .constant(true),
            selectedColor: .constant(.purple),
            onSwitchToProperties: {},
-           onSwitchToShapes: {}
+           onSwitchToShapes: {},
+           onSwitchToGallery: {}
        )
    }
 }

--- a/COMP-49X-24-25-PhoneArt/Views/GalleryPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/GalleryPanel.swift
@@ -1,0 +1,159 @@
+//
+//  GalleryPanel.swift
+//  COMP-49X-24-25-PhoneArt
+//
+//  Created by Emmett de Bruin on 2025-04-08.
+//
+
+
+import SwiftUI
+
+
+struct GalleryPanel: View {
+   // MARK: - Properties
+   @Binding var isShowing: Bool
+  
+   // Callbacks for switching panels
+   var onSwitchToProperties: () -> Void
+   var onSwitchToColorShapes: () -> Void
+   var onSwitchToShapes: () -> Void
+  
+   // MARK: - Body
+   var body: some View {
+       VStack(spacing: 0) {
+           // Header section with navigation buttons and close control
+           panelHeader()
+          
+           // Main content area (Placeholder)
+           ScrollView {
+               VStack {
+                   Text("Artwork Gallery")
+                       .font(.title2).bold()
+                       .padding(.top)
+                  
+                   Text("Saved artwork will appear here.")
+                       .foregroundColor(.secondary)
+                       .padding()
+                  
+                   // TODO: Add gallery content (e.g., grid of artwork previews)
+                   Spacer()
+               }
+               .frame(maxWidth: .infinity, maxHeight: .infinity)
+           }
+       }
+       .frame(maxWidth: .infinity)
+       .frame(height: UIScreen.main.bounds.height / 3) // Panel takes up one-third of screen height
+       .background(Color(.systemBackground))
+       .cornerRadius(15, corners: [.topLeft, .topRight])
+       .shadow(radius: 10)
+   }
+  
+   // MARK: - UI Components (Panel Header)
+  
+   /// Creates the header section of the panel containing navigation buttons and close control.
+   private func panelHeader() -> some View {
+       HStack(alignment: .center, spacing: 0) {
+           Spacer() // Left margin spacer for equal distribution
+          
+           makePropertiesButton()
+          
+           Spacer() // Spacer between buttons
+          
+           makeColorShapesButton()
+          
+           Spacer() // Spacer between buttons
+          
+           makeShapesButton()
+          
+           Spacer() // Spacer between buttons
+          
+           makeGalleryButton() // Current panel button
+          
+           Spacer() // Spacer between buttons
+          
+           // Close button
+           Button(action: {
+               withAnimation(.easeInOut(duration: 0.25)) {
+                   isShowing = false
+               }
+           }) {
+               buttonContent(icon: "xmark", isActive: false)
+           }
+           .accessibilityLabel("Close")
+           .accessibilityIdentifier("CloseButton")
+          
+           Spacer() // Right margin spacer
+       }
+       .padding(.horizontal)
+       .padding(.vertical, 4)
+       .background(Color(.systemGray5))
+       .cornerRadius(8, corners: [.topLeft, .topRight])
+   }
+  
+   // MARK: - Header Button Creation Helpers
+  
+   /// Generic button content view
+   @ViewBuilder
+   private func buttonContent(icon: String, isActive: Bool) -> some View {
+       Rectangle()
+           .foregroundColor(Color(uiColor: .systemBackground))
+           .frame(width: 50, height: 50)
+           .cornerRadius(8)
+           .overlay(
+               Image(systemName: icon)
+                   .font(.system(size: 22))
+                   .foregroundColor(Color(uiColor: .systemBlue))
+           )
+           .overlay(
+               RoundedRectangle(cornerRadius: 8)
+                   .stroke(isActive ? Color.clear : Color(uiColor: .systemGray3), lineWidth: 0.5) // Border only if not active
+           )
+           .shadow(radius: isActive ? 2 : 0) // Shadow only if active
+   }
+  
+   /// Creates a button that switches to the Properties panel.
+   private func makePropertiesButton() -> some View {
+       Button(action: onSwitchToProperties) {
+           buttonContent(icon: "slider.horizontal.3", isActive: false)
+       }
+       .accessibilityIdentifier("Properties Button")
+   }
+  
+   /// Creates a button that switches to the Color Shapes panel.
+   private func makeColorShapesButton() -> some View {
+       Button(action: onSwitchToColorShapes) {
+           buttonContent(icon: "square.3.stack.3d", isActive: false)
+       }
+       .accessibilityIdentifier("Color Shapes Button")
+   }
+  
+   /// Creates a button that switches to the Shapes panel.
+   private func makeShapesButton() -> some View {
+       Button(action: onSwitchToShapes) {
+           buttonContent(icon: "square.on.square", isActive: false)
+       }
+       .accessibilityIdentifier("Shapes Button")
+   }
+
+
+   /// Creates a button representing the current (Gallery) panel.
+   private func makeGalleryButton() -> some View {
+       Button(action: {
+           // No action needed - we're already in this panel
+       }) {
+           buttonContent(icon: "photo.on.rectangle.angled", isActive: true) // Active state
+       }
+       .accessibilityIdentifier("Gallery Button")
+   }
+}
+
+
+// MARK: - Preview
+#Preview {
+   GalleryPanel(
+       isShowing: .constant(true),
+       onSwitchToProperties: { print("Switch to Properties") },
+       onSwitchToColorShapes: { print("Switch to Color/Shapes") },
+       onSwitchToShapes: { print("Switch to Shapes") }
+   )
+}

--- a/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
@@ -45,6 +45,7 @@ struct PropertiesPanel: View {
  @Binding var isShowing: Bool
  var onSwitchToColorShapes: () -> Void  // Callback for switching to Color panel
  var onSwitchToShapes: () -> Void       // Callback for switching to Shapes panel
+ var onSwitchToGallery: () -> Void     // Callback for switching to Gallery panel
   // MARK: - Text Field States
   @State private var rotationText: String
  @State private var scaleText: String
@@ -78,7 +79,12 @@ struct PropertiesPanel: View {
              Spacer() // Spacer between buttons for equal distribution
             
              makeShapesButton()
-            
+
+             Spacer() // Spacer between buttons for equal distribution
+
+             // Add the Gallery Button
+             makeGalleryButton()
+
              Spacer() // Spacer between buttons for equal distribution
             
              // Close button
@@ -89,11 +95,11 @@ struct PropertiesPanel: View {
              }) {
                  Rectangle()
                      .foregroundColor(Color(uiColor: .systemBackground))
-                     .frame(width: 60, height: 60)
+                     .frame(width: 50, height: 50)
                      .cornerRadius(8)
                      .overlay(
                          Image(systemName: "xmark")
-                             .font(.system(size: 24))
+                             .font(.system(size: 22))
                              .foregroundColor(Color(uiColor: .systemBlue))
                      )
                      .overlay(
@@ -388,11 +394,11 @@ struct PropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "slider.horizontal.3")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .shadow(radius: 2)
@@ -407,11 +413,11 @@ struct PropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "square.3.stack.3d")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .overlay(
@@ -429,11 +435,11 @@ struct PropertiesPanel: View {
        }) {
            Rectangle()
                .foregroundColor(Color(uiColor: .systemBackground))
-               .frame(width: 60, height: 60)
+               .frame(width: 50, height: 50)
                .cornerRadius(8)
                .overlay(
                    Image(systemName: "square.on.square")
-                       .font(.system(size: 24))
+                       .font(.system(size: 22))
                        .foregroundColor(Color(uiColor: .systemBlue))
                )
                .overlay(
@@ -443,6 +449,29 @@ struct PropertiesPanel: View {
        }
        .accessibilityIdentifier("Shapes Button")
    }
+
+   /// Creates a button for the Gallery (placeholder).
+   internal func makeGalleryButton() -> some View {
+       Button(action: {
+           onSwitchToGallery() // Call the gallery switch callback
+       }) {
+           Rectangle()
+               .foregroundColor(Color(uiColor: .systemBackground))
+               .frame(width: 50, height: 50) // Set size
+               .cornerRadius(8)
+               .overlay(
+                   Image(systemName: "photo.on.rectangle.angled")
+                       .font(.system(size: 22)) // Set size
+                       .foregroundColor(Color(uiColor: .systemBlue))
+               )
+               .overlay(
+                   RoundedRectangle(cornerRadius: 8)
+                       .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
+               )
+       }
+       .accessibilityIdentifier("Gallery Button")
+   }
+
   // MARK: - Initialization
   /// Initializes a new PropertiesPanel with the given bindings
  /// - Parameters:
@@ -458,9 +487,10 @@ struct PropertiesPanel: View {
  ///   - isShowing: Binding for panel visibility
  ///   - onSwitchToColorShapes: Callback for switching to ColorPropertiesPanel
  ///   - onSwitchToShapes: Callback for switching to Shapes panel
+ ///   - onSwitchToGallery: Callback for switching to Gallery panel 
  init(rotation: Binding<Double>, scale: Binding<Double>, layer: Binding<Double>, skewX: Binding<Double>, skewY: Binding<Double>,
       spread: Binding<Double>, horizontal: Binding<Double>, vertical: Binding<Double>, primitive: Binding<Double>, isShowing: Binding<Bool>,
-      onSwitchToColorShapes: @escaping () -> Void, onSwitchToShapes: @escaping () -> Void) {
+      onSwitchToColorShapes: @escaping () -> Void, onSwitchToShapes: @escaping () -> Void, onSwitchToColorShapes: @escaping () -> Void, onSwitchToShapes: @escaping () -> Void, onSwitchToGallery: @escaping () -> Void) {
      self._rotation = rotation
      self._scale = scale
      self._layer = layer
@@ -473,6 +503,7 @@ struct PropertiesPanel: View {
      self._isShowing = isShowing
      self.onSwitchToColorShapes = onSwitchToColorShapes
      self.onSwitchToShapes = onSwitchToShapes
+     self.onSwitchToGallery = onSwitchToGallery
   
      // Initialize text fields with formatted values
      self._rotationText = State(initialValue: "\(Int(rotation.wrappedValue))")
@@ -628,7 +659,8 @@ struct PropertiesPanel_Previews: PreviewProvider {
            primitive: .constant(1),
            isShowing: .constant(true),
            onSwitchToColorShapes: {},
-           onSwitchToShapes: {}
+           onSwitchToShapes: {},
+           onSwitchToGallery: {}
        )
    }
 }

--- a/COMP-49X-24-25-PhoneArt/Views/ShapesPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/ShapesPanel.swift
@@ -59,6 +59,9 @@ struct ShapesPanel: View {
     /// Callback function to switch to the Color Properties panel
     var onSwitchToColorProperties: () -> Void
     
+    /// Callback function to switch to the Gallery panel
+    var onSwitchToGallery: () -> Void
+
     // MARK: - Body
     
     var body: some View {
@@ -101,6 +104,7 @@ struct ShapesPanel: View {
     /// - Properties panel button
     /// - Color properties panel button  
     /// - Shapes panel button (current panel)
+    /// - Gallery button
     /// - Close button
     internal func panelHeader() -> some View {
         // Panel header with evenly distributed buttons
@@ -116,7 +120,12 @@ struct ShapesPanel: View {
             Spacer() // Spacer between buttons for equal distribution
             
             makeShapesButton()
-            
+
+            Spacer() // Spacer between buttons for equal distribution
+
+            // Add the Gallery Button
+            makeGalleryButton()
+
             Spacer() // Spacer between buttons for equal distribution
             
             // Close button
@@ -127,11 +136,11 @@ struct ShapesPanel: View {
             }) {
                 Rectangle()
                     .foregroundColor(Color(uiColor: .systemBackground))
-                    .frame(width: 60, height: 60)
+                    .frame(width: 50, height: 50)
                     .cornerRadius(8)
                     .overlay(
                         Image(systemName: "xmark")
-                            .font(.system(size: 24))
+                            .font(.system(size: 22))
                             .foregroundColor(Color(uiColor: .systemBlue))
                     )
                     .overlay(
@@ -195,11 +204,11 @@ struct ShapesPanel: View {
         }) {
             Rectangle()
                 .foregroundColor(Color(uiColor: .systemBackground))
-                .frame(width: 60, height: 60)
+                .frame(width: 50, height: 50)
                 .cornerRadius(8)
                 .overlay(
                     Image(systemName: "slider.horizontal.3")
-                        .font(.system(size: 24))
+                        .font(.system(size: 22))
                         .foregroundColor(Color(uiColor: .systemBlue))
                 )
                 .overlay(
@@ -218,11 +227,11 @@ struct ShapesPanel: View {
         }) {
             Rectangle()
                 .foregroundColor(Color(uiColor: .systemBackground))
-                .frame(width: 60, height: 60)
+                .frame(width: 50, height: 50)
                 .cornerRadius(8)
                 .overlay(
                     Image(systemName: "square.3.stack.3d")
-                        .font(.system(size: 24))
+                        .font(.system(size: 22))
                         .foregroundColor(Color(uiColor: .systemBlue))
                 )
                 .overlay(
@@ -242,17 +251,39 @@ struct ShapesPanel: View {
         }) {
             Rectangle()
                 .foregroundColor(Color(uiColor: .systemBackground))
-                .frame(width: 60, height: 60)
+                .frame(width: 50, height: 50)
                 .cornerRadius(8)
                 .overlay(
                     Image(systemName: "square.on.square")
-                        .font(.system(size: 24))
+                        .font(.system(size: 22))
                         .foregroundColor(Color(uiColor: .systemBlue))
                 )
                 .shadow(radius: 2)
         }
         .accessibilityIdentifier("Shapes Button")
     }
+
+    /// Creates a button for the Gallery (placeholder).
+   internal func makeGalleryButton() -> some View {
+       Button(action: {
+           onSwitchToGallery() // Call the gallery switch callback
+       }) {
+           Rectangle()
+               .foregroundColor(Color(uiColor: .systemBackground))
+               .frame(width: 50, height: 50) // Set size
+               .cornerRadius(8)
+               .overlay(
+                   Image(systemName: "photo.on.rectangle.angled")
+                       .font(.system(size: 22)) // Set size
+                       .foregroundColor(Color(uiColor: .systemBlue))
+               )
+               .overlay(
+                   RoundedRectangle(cornerRadius: 8)
+                       .stroke(Color(uiColor: .systemGray3), lineWidth: 0.5)
+               )
+       }
+       .accessibilityIdentifier("Gallery Button")
+   }
 }
 
 // MARK: - Previews
@@ -264,7 +295,8 @@ struct ShapesPanel_Previews: PreviewProvider {
             selectedShape: .constant(.circle),
             isShowing: .constant(true),
             onSwitchToProperties: {},
-            onSwitchToColorProperties: {}
+            onSwitchToColorProperties: {},
+            onSwitchToGallery: {} // Add dummy callback for preview
         )
     }
 }


### PR DESCRIPTION
# Overview

**Type of Change:** New UI

**Summary:** This pull request introduces the basic UI structure for a new "Gallery" feature. It adds a "Gallery" button to the main bottom toolbar in `CanvasView` and also includes this button in the headers of the existing `PropertiesPanel`, `ColorPropertiesPanel`, and `ShapesPanel` for consistent navigation. A new file, `GalleryPanel.swift`, has been created to house the view for this feature, currently containing placeholder content and the standard panel header. State management and panel switching logic in `CanvasView` have been updated to accommodate this new panel. Buttons in affected toolbars were resized to fit the additional button.

# UI/UX Implementation

A new button featuring a gallery icon ("photo.on.rectangle.angled") has been added to the application:

1.  **Main Toolbar:** The button is now present in the bottom toolbar of the main `CanvasView`, alongside the Properties, Color/Shapes, Shapes, and Close buttons.
2.  **Panel Headers:** The same gallery button has been added to the header/toolbar row within `PropertiesPanel`, `ColorPropertiesPanel`, and `ShapesPanel` when they are presented.
3.  **Button Resizing:** To accommodate the new button, all buttons in the main bottom toolbar and the headers of the aforementioned panels have been resized from 60x60 to 50x50.
4.  **New Panel:** Tapping the gallery button (either on the main toolbar or within another panel's header) now presents a new `GalleryPanel`. Currently, this panel displays a title ("Artwork Gallery") and placeholder text ("Saved artwork will appear here."), along with the standard panel header allowing navigation to other panels or closing.

# Model Updates

*   **Data Models:** No changes made.
*   **Object-Oriented Models:** No changes made. 

# End-to-End Testing Instructions

1.  Build and run the application.
2.  Observe the main `CanvasView`. Verify that the bottom toolbar now displays five icon buttons (Properties, Color/Shapes, Shapes, Gallery, Close).
3.  Tap the "Gallery" icon (photo on rectangle) in the bottom toolbar.
4.  Verify that the `GalleryPanel` slides up from the bottom, displaying the title "Artwork Gallery", placeholder text, and a header toolbar containing the five icons.
5.  From the `GalleryPanel` header, tap the "Properties" icon (sliders). Verify the `GalleryPanel` closes and the `PropertiesPanel` opens.
6.  From the `PropertiesPanel` header, verify the "Gallery" icon is present. Tap it.
7.  Verify the `PropertiesPanel` closes and the `GalleryPanel` opens again.
8.  Repeat steps 5-7 for the "Color/Shapes" (stacked squares) and "Shapes" (overlapping squares) icons, verifying correct switching between the respective panels and the `GalleryPanel`.
9.  With the `GalleryPanel` open, tap the "Close" icon ('X') in its header. Verify the `GalleryPanel` closes.
10. Open any panel (e.g., tap the "Properties" button in the main bottom bar). Verify the panel opens.
11. Tap the "Close" icon ('X') in the main bottom bar. Verify the open panel closes.
