### PR TITLE
Implemented edit and rename button UI

### DIFF
--- a/COMP-49X-24-25-PhoneArt/Views/GalleryPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/GalleryPanel.swift
@@ -400,22 +400,61 @@ struct ArtworkGridItem: View {
     }()
 
     var body: some View {
-        VStack(alignment: .leading) {
-            // Display the generated thumbnail or a placeholder
-            Image(uiImage: thumbnail ?? placeholder)
-                .resizable()
-                .aspectRatio(1, contentMode: .fit) // Keep it square
-                .background(Color(.systemGray6)) // Background behind the image
-                .cornerRadius(8)
+        VStack(alignment: .leading, spacing: 8) {
+           // Display the generated thumbnail or a placeholder
+           Image(uiImage: thumbnail ?? placeholder)
+               .resizable()
+               .aspectRatio(1, contentMode: .fit) // Keep it square
+               .background(Color(.systemGray6)) // Background behind the image
+               .cornerRadius(8)
 
-            Text(artwork.title ?? "Untitled")
-                .font(.caption.weight(.semibold))
-                .lineLimit(1)
 
-            Text(Self.dateFormatter.string(from: artwork.timestamp))
-                .font(.caption2)
-                .foregroundColor(.secondary)
-        }
+           // Row with title/date on left and action buttons on right
+           HStack {
+               // Title and timestamp on the left
+               VStack(alignment: .leading, spacing: 2) {
+                   Text(artwork.title ?? "Untitled")
+                       .font(.caption.weight(.semibold))
+                       .lineLimit(1)
+
+
+                   Text(Self.dateFormatter.string(from: artwork.timestamp))
+                       .font(.caption2)
+                       .foregroundColor(.secondary)
+               }
+              
+               Spacer()
+              
+               // Action buttons on the right
+               HStack(spacing: 8) {
+                   // Edit/Rename button
+                   Button(action: {
+                       // Just UI for now - no action
+                       print("Edit/Rename button tapped for: \(artwork.id)")
+                   }) {
+                       Image(systemName: "pencil")
+                           .font(.system(size: 14))
+                           .foregroundColor(.blue)
+                   }
+                   .frame(width: 30, height: 30)
+                   .background(Color(.systemBackground))
+                   .cornerRadius(4)
+                  
+                   // Delete button
+                   Button(action: {
+                       // Just UI for now - no action
+                       print("Delete button tapped for: \(artwork.id)")
+                   }) {
+                       Image(systemName: "trash")
+                           .font(.system(size: 14))
+                           .foregroundColor(.red)
+                   }
+                   .frame(width: 30, height: 30)
+                   .background(Color(.systemBackground))
+                   .cornerRadius(4)
+               }
+           }
+       }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Artwork titled \(artwork.title ?? "Untitled"), saved \(Self.dateFormatter.string(from: artwork.timestamp))")
     }


### PR DESCRIPTION
# Pull Request Template

## Overview

Type of Change: New UI Feature

Summary: Added UI elements for artwork management functionality in the Gallery Panel. Implemented edit/rename and delete buttons for each artwork item to improve user interaction with saved artwork. The buttons are visually implemented but not yet connected to backend functionality.

## UI/UX Implementation

Changes made to the UI/UX include adding two action buttons to each artwork item in the gallery:
- A pencil icon button for editing/renaming artwork
- A trash icon button for deleting artwork

The buttons are positioned in the same row as the artwork title and timestamp information, creating an interface for artwork management. Each button has appropriate visual styling (blue for edit, red for delete) with proper spacing and sizing.


## Model Updates

### Data Models
No changes made.

### Object-Oriented Models
No changes made. This PR only implements the UI elements; the functionality for these actions will be added in a future PR.

## End-to-End Testing Instructions

1. Launch the application
2. Create or load an artwork
3. Open the Gallery Panel by tapping the gallery button in the bottom toolbar
4. Verify that each artwork item in the gallery shows:
   - A thumbnail image of the artwork
   - The artwork title and timestamp
   - A blue pencil icon and a red trash icon on the right side
5. Tap on the pencil and trash icons and verify that appropriate console messages appear (actual functionality to be implemented in a future update)

Note: The current implementation is UI-only; the buttons will print to the console but won't perform any actual editing or deletion actions yet.
