### PR TITLE
Adjusted the following properties: Scale, SKew, Layers, Color Alpha

### DIFF
--- a/COMP-49X-24-25-PhoneArt/Models/ArtworkData.swift
+++ b/COMP-49X-24-25-PhoneArt/Models/ArtworkData.swift
@@ -25,7 +25,7 @@ struct ArtworkData: Codable, Identifiable, Equatable {
   private struct ValidationRanges {
       static let rotation = 0.0...360.0    // Rotation angle in degrees
       static let scale = 0.5...2.0         // Scale factor
-      static let layer = 0.0...360.0       // Layer ordering
+      static let layer = 0.0...72.0       // Layer ordering
       static let skew = 0.0...100.0        // Skew percentage
       static let spread = 0.0...100.0      // Element spread percentage
       static let horizontal = -300.0...300.0 // Horizontal position

--- a/COMP-49X-24-25-PhoneArt/Services/ColorUtils.swift
+++ b/COMP-49X-24-25-PhoneArt/Services/ColorUtils.swift
@@ -30,7 +30,9 @@ struct ColorUtils {
             // Adjust saturation (scale by 0-1) always
             let newSaturation = min(1.0, max(0.0, saturation * CGFloat(saturationScale)))
 
-            return Color(hue: Double(newHue), saturation: Double(newSaturation), brightness: Double(brightness), opacity: Double(alpha))
+            // Always return a fully opaque color from adjustColor.
+            // Final opacity is handled later in the drawing code based on shapeAlpha.
+            return Color(hue: Double(newHue), saturation: Double(newSaturation), brightness: Double(brightness), opacity: 1.0)
         }
 
         // Return original color if conversion fails

--- a/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
@@ -12,7 +12,7 @@ import UIKit
 /// This panel includes sliders and text inputs for precise control over:
 /// - Rotation (0-360 degrees)
 /// - Scale (0.5x-2.0x)
-/// - Layer count (0-360)
+/// - Layer count (0-72)
 /// - SkewX and SkewY (0-100)
 /// - Spread (0-100)
 /// - Horizontal position (0-300)
@@ -245,7 +245,7 @@ struct PropertiesPanel: View {
  private func layerPropertyRow() -> some View {
      propertyRow(title: "Layer", icon: "square.3.stack.3d") {
          HStack {
-             Slider(value: $layer, in: 0...360)
+             Slider(value: $layer, in: 0...72)
                  .accessibilityIdentifier("Layer Slider")
                  .onChange(of: layer) { _, newValue in
                      layerText = "\(Int(newValue))"
@@ -257,7 +257,7 @@ struct PropertiesPanel: View {
                  .keyboardType(UIKeyboardType.numberPad)
                  .multilineTextAlignment(.center)
                  .onChange(of: layerText) { _, newValue in
-                     if let value = Double(newValue), value >= 0, value <= 360 {
+                     if let value = Double(newValue), value >= 0, value <= 72 {
                          layer = value
                      }
                  }

--- a/COMP-49X-24-25-PhoneArtTests/ArtworkDataTests.swift
+++ b/COMP-49X-24-25-PhoneArtTests/ArtworkDataTests.swift
@@ -97,7 +97,7 @@ final class ArtworkDataTests: XCTestCase {
         // Verify all values are clamped to their valid ranges
         XCTAssertEqual(decoded["rotation"], "360.0") // Max rotation
         XCTAssertEqual(decoded["scale"], "2.0") // Max scale
-        XCTAssertEqual(decoded["layer"], "360.0") // Max layer
+        XCTAssertEqual(decoded["layer"], "72.0") // Max layer
         XCTAssertEqual(decoded["skewX"], "100.0") // Max skew
         XCTAssertEqual(decoded["skewY"], "100.0") // Max skew
         XCTAssertEqual(decoded["spread"], "100.0") // Max spread

--- a/COMP-49X-24-25-PhoneArtTests/CanvasViewTests.swift
+++ b/COMP-49X-24-25-PhoneArtTests/CanvasViewTests.swift
@@ -65,7 +65,7 @@ final class CanvasViewTests: XCTestCase {
    func testValidationBoundaries() {
        // Test layer count validation
        XCTAssertEqual(sut.testValidateLayerCount(-1), 0, "Negative layer count should be clamped to 0")
-       XCTAssertEqual(sut.testValidateLayerCount(500), 360, "Excessive layer count should be clamped to 360")
+       XCTAssertEqual(sut.testValidateLayerCount(500), 72, "Excessive layer count should be clamped to 72")
        XCTAssertEqual(sut.testValidateLayerCount(50), 50, "Valid layer count should remain unchanged")
       
        // Test scale validation
@@ -150,7 +150,7 @@ final class CanvasViewTests: XCTestCase {
    /// Tests the validation methods using their expected implementations
    func testValidationImplementation() {
        // Verify the implementation matches expected behavior (uses max/min functions)
-       XCTAssertEqual(sut.testValidateLayerCount(-5), max(0, min(360, -5)), "Layer count validation should use max/min")
+       XCTAssertEqual(sut.testValidateLayerCount(-5), max(0, min(72, -5)), "Layer count validation should use max/min")
        XCTAssertEqual(sut.testValidateScale(2.5), max(0.5, min(2.0, 2.5)), "Scale validation should use max/min")
        XCTAssertEqual(sut.testValidateRotation(400), max(0.0, min(360.0, 400)), "Rotation validation should use max/min")
        XCTAssertEqual(sut.testValidateSkewX(120), max(0.0, min(100.0, 120)), "SkewX validation should use max/min")
@@ -591,7 +591,7 @@ extension CanvasView {
    // Extension methods below are for TESTING ONLY and do not affect code coverage
    // For validation methods
    func testValidateLayerCount(_ count: Int) -> Int {
-       max(0, min(360, count))
+       max(0, min(72, count))
    }
  
    func testValidateScale(_ scale: Double) -> Double {

--- a/COMP-49X-24-25-PhoneArtTests/PropertiesPanelTests.swift
+++ b/COMP-49X-24-25-PhoneArtTests/PropertiesPanelTests.swift
@@ -129,7 +129,7 @@ final class PropertiesPanelTests: XCTestCase {
  /// Verifies the following ranges:
  /// - Rotation: 0° to 360°
  /// - Scale: 0.5x to 2.0x
- /// - Layer count: 0 to 360 layers
+ /// - Layer count: 0 to 72 layers
  /// - Skew X/Y: 0% to 80%
  /// - Spread: 0% to 100%
  /// - Horizontal/Vertical: -500 to 500
@@ -140,8 +140,8 @@ final class PropertiesPanelTests: XCTestCase {
      // Test scale range (0.5x to 2.0x magnification)
      XCTAssertTrue((0.5...2.0).contains(scale))
   
-     // Test layer range (0-360 layers)
-     XCTAssertTrue((0...360).contains(layer))
+     // Test layer range (0-72 layers)
+     XCTAssertTrue((0...72).contains(layer))
   
      // Test skew ranges (0-80%)
      XCTAssertTrue((0...80).contains(skewX))
@@ -169,7 +169,7 @@ final class PropertiesPanelTests: XCTestCase {
      XCTAssertEqual(invalidScale, 2.0)
   
      // Test layer bounds - should clamp -5 to 0
-     let invalidLayer = max(0, min(-5, 360))
+     let invalidLayer = max(0, min(-5, 72))
      XCTAssertEqual(invalidLayer, 0)
   
      // Test skew X bounds - should clamp 90% to 80%
@@ -191,7 +191,7 @@ final class PropertiesPanelTests: XCTestCase {
  /// Tests validation for:
  /// - Rotation (0-360°)
  /// - Scale (0.5x-2.0x)
- /// - Layer count (0-360)
+ /// - Layer count (0-72)
  /// - Skew X/Y (0-80%)
  /// - Spread (0-100%)
  /// - Horizontal/Vertical position (-500 to 500)
@@ -207,10 +207,10 @@ final class PropertiesPanelTests: XCTestCase {
          ("scale", 1.5, 1.5),
          ("scale", 2.5, 2.0),
       
-         // Layer tests - validates clamping at 0 and 360 layers
+         // Layer tests - validates clamping at 0 and 72 layers
          ("layer", -10.0, 0.0),
          ("layer", 50.0, 50.0),
-         ("layer", 500.0, 360.0),
+         ("layer", 500.0, 72.0),
       
          // Skew tests - validates 0-80% range for both X and Y
          ("skewX", -30.0, 0.0),

--- a/COMP-49X-24-25-PhoneArtTests/TransformationTests.swift
+++ b/COMP-49X-24-25-PhoneArtTests/TransformationTests.swift
@@ -171,18 +171,18 @@ final class TransformationTests: XCTestCase {
       let testCases = [
           (layerCount: 1, expectedLayers: 1),
           (layerCount: 3, expectedLayers: 3),
-          (layerCount: 360, expectedLayers: 360)
+          (layerCount: 72, expectedLayers: 72)
       ]
     
       for testCase in testCases {
-          let numberOfLayers = max(0, min(360, testCase.layerCount))
+          let numberOfLayers = max(0, min(72, testCase.layerCount))
           XCTAssertEqual(numberOfLayers, testCase.expectedLayers,
                         "Layer count calculation failed")
         
           // Test that each layer index is valid
           if numberOfLayers > 0 {
               for layerIndex in 0..<numberOfLayers {
-                  XCTAssertTrue((0..<360).contains(layerIndex),
+                  XCTAssertTrue((0..<72).contains(layerIndex),
                               "Layer index \(layerIndex) out of bounds")
               }
           }


### PR DESCRIPTION
# Overview

**Type of Change:** Bug Fix

**Summary:** This pull request addresses the issue of incorrect layer bounds and updates the skew, scale, and alpha properties to ensure they adhere to the specified ranges. The layer bounds were adjusted from 0-360 to 0-72. Additionally, the skew strength was increased to make the adjustment 1:1, meaning each value now represents a degree of skew. The alpha property was adjusted so that the shape opacity is 100% when alpha is 100%, rather than the previous 90%.

## UI/UX Implementation

No changes made.

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes made.

### Object-Oriented Models

The `ArtworkData` model was updated to reflect the new layer bounds. The `ValidationRanges` struct within `ArtworkData` was modified to set the layer range to 0-72. Additionally, the validation logic for skew was updated to ensure a 1:1 adjustment, where each value represents a degree of skew. The alpha property was adjusted to ensure full opacity at 100%.

## End-to-End Testing Instructions

1. **Layer Validation:**
   - Open the application and navigate to the properties panel.
   - Adjust the layer slider and ensure it only allows values between 0 and 72.
   - Enter a value outside this range in the text field and verify it is clamped to the nearest valid value.

2. **Skew Validation:**
   - Adjust the skew sliders (Skew X and Skew Y) and ensure they now represent a 1:1 degree of skew.
   - Enter a value in the text fields and verify the skew adjustment reflects a degree-based change.

3. **Scale Validation:**
   - Adjust the scale slider and ensure it only allows values between 0.5 and 2.0.
   - Enter a value outside this range in the text field and verify it is clamped to the nearest valid value.

4. **Alpha Validation:**
   - Ensure that the alpha property now results in full opacity at 100%.
   - Adjust the alpha value and verify that the shape opacity changes accordingly, reaching full opacity at 100%.

By following these steps, you can verify that the changes to the layer, skew, scale, and alpha properties are functioning as expected, with the skew and alpha adjustments providing the intended effects.