### PR TITLE
Removed "x" and degree symbols

### DIFF
--- a/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
+++ b/COMP-49X-24-25-PhoneArt/Views/PropertiesPanel.swift
@@ -213,7 +213,6 @@ struct PropertiesPanel: View {
                          rotation = value
                      }
                  }
-             Text("°")
          }
      }
  }
@@ -237,7 +236,6 @@ struct PropertiesPanel: View {
                          scale = value
                      }
                  }
-             Text("x")
          }
      }
  }


### PR DESCRIPTION
# Overview

**Type of Change:**  Bug Fix

**Summary:** Removed "x" and degree marks from appearing on respective sliders in order to simplify use / possible confusion.

## UI/UX Implementation

Changed the appearance of the slider value to now appear without a unit sign.
Ex:
1. Before:
*   The scale slider showed a value like "1.0 x".
*   The rotation slider showed a value like "90 °".
2. After:
*   The scale slider just shows "1.0".
*   The rotation slider just shows "90".

## Model Updates

This section describes changes that were made to the models used by your application.

### Data Models

No changes.

### Object-Oriented Models

No changes made.

